### PR TITLE
Add set reset to simulation

### DIFF
--- a/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
+++ b/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
@@ -117,7 +117,6 @@ static void UpdateStateMachine(void* data)
 	// update state
 	state = new_state;
 
-	char buffer[32];
 	sprintf(buffer, "NEW STATE: %d", state);
 	Log(buffer);
 }

--- a/VCU/Phantom/Drivers/UART/Phantom_sci.c
+++ b/VCU/Phantom/Drivers/UART/Phantom_sci.c
@@ -146,11 +146,14 @@ void sciReceiveCallback(sciBASE_t *sci, uint32 flags, uint8 data)
 
 		messageCounter++;
 
+		// Refer to VCU Simulation Document: https://docs.google.com/document/d/1JWH6s5qf8QeWGzkVzae5GWXK8BNsT8EGFw0WuFVnmiY/edit
+		// last byte 33:40
 		if (messageCounter == NUMBER_OF_SIMULATION_MESSAGES)
 		{
 			// extract tsal 
 			uint8_t tsal = (data >> 2) & 0b11;
 			uint8_t rtds = (data >> 4) & 0b11;
+			uint8_t set_reset = (data >> 6) & 0b11;
 
 			if (tsal & SERIAL_INTRPT_MASK)
 			{
@@ -162,6 +165,11 @@ void sciReceiveCallback(sciBASE_t *sci, uint32 flags, uint8 data)
 			{
 			    LogFromISR(RED, "Ready to drive!");
 //				NotifyStateMachineFromISR(EVENT_READY_TO_DRIVE);
+			}
+
+			if (set_reset & SERIAL_INTRPT_MASK)
+			{
+			    LogFromISR(RED, (set_reset) & SERIAL_INTRPT_VALUE_MASK ? "SET" : "RESET");
 			}
 		}
 	}

--- a/command-line/test_phantom_encode.py
+++ b/command-line/test_phantom_encode.py
@@ -48,16 +48,26 @@ def test_interrupt_output():
 	assert "EVENT_TRACTIVE_OFF" in response, response
 	ret += response
 
+	response = vcu.write(set_reset_flip=True, delay_s=0.5)
+	assert "SET" in response, response
+	ret += response
+
+	response = vcu.write(set_reset_flip=True, delay_s=0.5)
+	assert "RESET" in response, response
+	ret += response
+
+	response = vcu.write(set_reset_flip=True, delay_s=0.5)
+	assert "SET" in response, response
+	ret += response
+
 	response = vcu.write(delay_s=0.5)
-	assert all(r not in response for r in ["EVENT_TRACTIVE_ON", "EVENT_TRACTIVE_OFF", "Ready to drive!"]), response
+	assert all(r not in response for r in ["SET", "RESET", "EVENT_TRACTIVE_ON", "EVENT_TRACTIVE_OFF", "Ready to drive!"]), response
 	ret += response
 
 	print(f"{test_interrupt_output.__name__} passed!")
 	return ret 
-	
-
 
 if __name__ == '__main__':
-	test_interrupt_output()
+	# test_interrupt_output()
 	test_throttle_output()
 	# test_latency()

--- a/command-line/vcu_simulation.py
+++ b/command-line/vcu_simulation.py
@@ -18,6 +18,7 @@ class VCUSimulation:
 	_port: str
 	_rtds: bool = False
 	_tsal: bool = False
+	_set_reset: bool = False
 
 	_apps1: int = APPS1_MIN
 	_apps2: int = APPS2_MIN
@@ -64,7 +65,7 @@ class VCUSimulation:
 
 		self._logger("Initializing logger...")
 
-	def __encode(self, a1: int, a2: int, bse: int, tsal_flip: bool, rtds_flip: bool) -> bytes:
+	def __encode(self, a1: int, a2: int, bse: int, tsal_flip: bool, rtds_flip: bool, set_reset_flip: bool) -> bytes:
 
 		# update internal state values
 		self._apps1 = a1
@@ -74,19 +75,22 @@ class VCUSimulation:
 		# if we're sending interrupts, add their signal value
 		tsal_val = tsal_flip << 1 | self.flip("_tsal", tsal_flip)
 		rtds_val = rtds_flip << 1 | self.flip("_rtds", rtds_flip)
+		set_reset_val = set_reset_flip << 1 | self.flip("_set_reset", set_reset_flip)
 
 		assert a1 in range(APPS1_MIN, APPS1_MAX+1)  and a2 in range(APPS2_MIN, APPS2_MAX+1), 'Outside of range'
-		value = (a1-APPS1_MIN) | (a2-APPS2_MIN) << 12 | (bse-BSE_MIN) << 22 | tsal_val << 34 | rtds_val << 36  # shift range to zero 
+
+		# shift range to zero 
+		value = (a1-APPS1_MIN) | (a2-APPS2_MIN) << 12 | (bse-BSE_MIN) << 22 | tsal_val << 34 | rtds_val << 36 | set_reset_val << 38
 		return value.to_bytes(5, byteorder='little')
 
-	def write(self, a1: int=None, a2: int=None, bse: int=None, tsal_flip: bool=False, rtds_flip: bool=False, delay_s: int=0):
+	def write(self, a1: int=None, a2: int=None, bse: int=None, tsal_flip: bool=False, rtds_flip: bool=False, set_reset_flip: bool=False, delay_s: int=0):
 
 		# use cached values if none provided
 		a1 = self._apps1 if a1 is None else a1
 		a2 = self._apps2 if a2 is None else a2
 		bse = self._bse if bse is None else bse
 		
-		message = self.__encode(a1, a2, bse, tsal_flip, rtds_flip)
+		message = self.__encode(a1, a2, bse, tsal_flip, rtds_flip, set_reset_flip)
 
 		self._logger(f"Sending {message}...")
 


### PR DESCRIPTION
Add set/reset as a signal for @kevinl03 's testing simulation. This allows us to have tests that check that the VCU handles this signal properly

Quick Python sanity test passes:
>> python .\test_phantom_encode.py COM5
Initializing logger...
Sending b'\x00\x00\x00\x00<'...
[FromISR:516.94] EVENT_TRACTIVE_ON
[FromISR:516.94] Ready to drive!
[PedalReadings:516.94] 1500 500 1500
[PedalReadings:516.95] Setting brakelight: 0

Sending b'\x00\x00\x00\x00('...
[FromISR:517.16] EVENT_TRACTIVE_OFF
[PedalReadings:517.16] 1500 500 1500

Sending b'\x00\x00\x00\x00\xc0'...
[FromISR:517.38] SET
[PedalReadings:517.38] 1500 500 1500

Sending b'\x00\x00\x00\x00\x80'...
[FromISR:517.60] RESET
[PedalReadings:517.60] 1500 500 1500

Sending b'\x00\x00\x00\x00\xc0'...
[FromISR:517.82] SET
[PedalReadings:517.82] 1500 500 1500

Sending b'\x00\x00\x00\x00@'...
[PedalReadings:518.03] 1500 500 1500

test_interrupt_output passed!