### PR TITLE
Output relevant signals during a severe fault scenario #44

### DIFF
--- a/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
+++ b/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
@@ -14,6 +14,7 @@
 #include "task_event_handler.h"
 #include "task_throttle.h"
 #include "task_logger.h"
+#include "board_hardware.h"
 
 static void UpdateStateMachine(void* data);
 static State VariousStates(State state, eCarEvents event);
@@ -25,13 +26,11 @@ static State SevereFault(eCarEvents event);
 
 static SystemTasks_t system_tasks;
 
-void VCU_FLT_Set()
+void VCU_FLT_Set(int value)
 {
 	//Toggles VCU_FLT pin defined in hardware file.
 
-	gioSetBit(SHUTDOWN_CIRCUIT_PORT,BSPD_FAULT_PIN,1);//Check pin since no VCU_FLT pin is defined.
-	
-	LogColor(RED, "Setting VCU_FLT signal.");
+	gioSetBit(SHUTDOWN_CIRCUIT_PORT,BSPD_FAULT_PIN,value);//Check pin since no VCU_FLT pin is defined in the hardware file. We assumed no latch is available thus fault must stay until car reset.
 
 	return;
 }
@@ -149,7 +148,9 @@ static State VariousStates(State state, eCarEvents event)
 	{
 		SuspendThrottle(system_tasks.Throttle);
 
-		VCU_FLT_Set();
+		VCU_FLT_Set(1);//Sets VCU_FLT to 1
+
+	    LogColor(RED, "Setting VCU_FLT signal.");
 		
 		LogColor(RED, "Moving to SevereFault state");
 
@@ -202,6 +203,11 @@ static State SevereFault(eCarEvents event)
 	if (event == EVENT_RESET_CAR)
 	{
 		LogColor(CYN, "Moving from SevereFault to TractiveOff");
+
+		VCU_FLT_Set(0); //Clearing VCU FLT --> Assuming the reset car event triggers.
+
+		LogColor(CYN, "Clearing VCU_FLT signal");
+
 		return TRACTIVE_OFF;
 	}
 

--- a/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
+++ b/VCU/Phantom/Drivers/STATE_MACHINE/state_machine.c
@@ -25,6 +25,16 @@ static State SevereFault(eCarEvents event);
 
 static SystemTasks_t system_tasks;
 
+void VCU_FLT_Set()
+{
+	//Toggles VCU_FLT pin defined in hardware file.
+
+	gioSetBit(SHUTDOWN_CIRCUIT_PORT,BSPD_FAULT_PIN,1);//Check pin since no VCU_FLT pin is defined.
+	
+	LogColor(RED, "Setting VCU_FLT signal.");
+
+	return;
+}
 
 /* Public API */
 
@@ -138,6 +148,8 @@ static State VariousStates(State state, eCarEvents event)
 	if (faults && state != SEVERE_FAULT)
 	{
 		SuspendThrottle(system_tasks.Throttle);
+
+		VCU_FLT_Set();
 		
 		LogColor(RED, "Moving to SevereFault state");
 

--- a/VCU/Phantom/Drivers/UART/Phantom_sci.c
+++ b/VCU/Phantom/Drivers/UART/Phantom_sci.c
@@ -31,6 +31,7 @@ enum eCommands{
 	RESET_CAR='r',
 	START_ENGINE='s',
 	TURN_TRACTIVE_ON='o',
+	SEVERE_FAULT_TEST='f',
 };
 
 static volatile uint8_t messageCounter = 0;
@@ -227,6 +228,12 @@ void sciReceiveCallback(sciBASE_t *sci, uint32 flags, uint8 data)
 			NotifyStateMachineFromISR(EVENT_RESET_CAR);
 
 			break;
+		}
+		case SEVERE_FAULT_TEST:
+		{
+		    NotifyStateMachineFromISR(EVENT_UNRESPONSIVE_APPS);
+
+		    break;
 		}
 		default:
 		{


### PR DESCRIPTION
Issue #44
Solved issue 44,
![image](https://github.com/user-attachments/assets/7188d9dd-5bca-49ba-b1c5-04a5fc79e9b0)
![image](https://github.com/user-attachments/assets/9d810691-a266-430c-8eea-a99126936c10)

 implemented the VCU_FLT set function and included the test case. Correct output is seen from above.